### PR TITLE
Fixes #2993

### DIFF
--- a/lib/Horde/Text/Diff/Engine/Native.php
+++ b/lib/Horde/Text/Diff/Engine/Native.php
@@ -336,7 +336,7 @@ class Horde_Text_Diff_Engine_Native
         $i = 0;
         $j = 0;
 
-        assert('count($lines) == count($changed)');
+        assert(count($lines) == count($changed));
         $len = count($lines);
         $other_len = count($other_changed);
 
@@ -357,7 +357,7 @@ class Horde_Text_Diff_Engine_Native
             }
 
             while ($i < $len && ! $changed[$i]) {
-                assert('$j < $other_len && ! $other_changed[$j]');
+                assert($j < $other_len && ! $other_changed[$j]);
                 $i++; $j++;
                 while ($j < $other_len && $other_changed[$j]) {
                     $j++;
@@ -389,11 +389,11 @@ class Horde_Text_Diff_Engine_Native
                     while ($start > 0 && $changed[$start - 1]) {
                         $start--;
                     }
-                    assert('$j > 0');
+                    assert($j > 0);
                     while ($other_changed[--$j]) {
                         continue;
                     }
-                    assert('$j >= 0 && !$other_changed[$j]');
+                    assert($j >= 0 && !$other_changed[$j]);
                 }
 
                 /* Set CORRESPONDING to the end of the changed run, at the
@@ -414,7 +414,7 @@ class Horde_Text_Diff_Engine_Native
                         $i++;
                     }
 
-                    assert('$j < $other_len && ! $other_changed[$j]');
+                    assert($j < $other_len && ! $other_changed[$j]);
                     $j++;
                     if ($j < $other_len && $other_changed[$j]) {
                         $corresponding = $i;
@@ -430,11 +430,11 @@ class Horde_Text_Diff_Engine_Native
             while ($corresponding < $i) {
                 $changed[--$start] = 1;
                 $changed[--$i] = 0;
-                assert('$j > 0');
+                assert($j > 0);
                 while ($other_changed[--$j]) {
                     continue;
                 }
-                assert('$j >= 0 && !$other_changed[$j]');
+                assert($j >= 0 && !$other_changed[$j]);
             }
         }
     }


### PR DESCRIPTION
Fixed to comply with the statement from php.net 
"Using string as the assertion is DEPRECATED as of PHP 7.2."

https://www.php.net/manual/tr/function.assert.php